### PR TITLE
Add Linux Azure Diagnostics feed to the function

### DIFF
--- a/AzureFunctionForSplunk/AzureFunctionForSplunk.csproj
+++ b/AzureFunctionForSplunk/AzureFunctionForSplunk.csproj
@@ -13,7 +13,7 @@
     <None Update="ActivityLogCategories.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="WadCategories.json">
+    <None Update="LadCategories.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="DiagnosticLogCategories.json">

--- a/AzureFunctionForSplunk/AzureMonitorMessage.cs
+++ b/AzureFunctionForSplunk/AzureMonitorMessage.cs
@@ -91,6 +91,85 @@ namespace AzureFunctionForSplunk
         }
     }
 
+    public class LadMetricMessage : AzureMonitorMessage
+    {
+        public LadMetricMessage(string resourceId, dynamic message)
+        {
+            ResourceId = resourceId;
+            Message = message;
+
+            GetStandardProperties();
+
+            AddStandardProperties();
+
+        }
+
+        private void AddStandardProperties()
+        {
+            if (SubscriptionId != "")
+            {
+                Message.azlm_SubscriptionId = SubscriptionId;
+            }
+            if (ResourceGroup != "")
+            {
+                Message.azlm_ResourceGroup = ResourceGroup;
+            }
+            if (ResourceType != "")
+            {
+                Message.azlm_ResourceType = ResourceType;
+            }
+            if (ResourceName != "")
+            {
+                Message.azlm_ResourceName = ResourceName;
+            }
+        }
+    }
+
+    public class LadLogMessage : AzureMonitorMessage
+    {
+        public LadLogMessage(string resourceId, dynamic message)
+        {
+            ResourceId = resourceId;
+            Message = message;
+
+            GetStandardProperties();
+
+            AddStandardProperties();
+
+        }
+
+        private void AddStandardProperties()
+        {
+            if (SubscriptionId != "")
+            {
+                Message.azll_SubscriptionId = SubscriptionId;
+            }
+            if (ResourceGroup != "")
+            {
+                Message.azll_ResourceGroup = ResourceGroup;
+            }
+            if (ResourceType != "")
+            {
+                Message.azll_ResourceType = ResourceType;
+            }
+            if (ResourceName != "")
+            {
+                Message.azll_ResourceName = ResourceName;
+            }
+        }
+    }
+
+    public class LadUnknownMessage : AzureMonitorMessage
+    {
+        public LadUnknownMessage(dynamic message)
+        {
+            ResourceId = "";
+            Message = message;
+
+        }
+
+    }
+
     public class MetricMessage : AzureMonitorMessage
     {
         public MetricMessage(string resourceId, dynamic message)

--- a/AzureFunctionForSplunk/AzureMonitorMessage.cs
+++ b/AzureFunctionForSplunk/AzureMonitorMessage.cs
@@ -165,9 +165,122 @@ namespace AzureFunctionForSplunk
         {
             ResourceId = "";
             Message = message;
-
+            Message.azlz_ResourceType = "MICROSOFT.COMPUTE/VIRTUALMACHINES";
         }
 
+    }
+
+    public class WadMetricMessage : AzureMonitorMessage
+    {
+        public WadMetricMessage(dynamic message, bool hasName)
+        {
+            ResourceId = "";
+            Message = message;
+
+            ResourceType = "MICROSOFT.COMPUTE/VIRTUALMACHINES";
+            if (hasName)
+            {
+                string theName = message.dimensions.RoleInstance;
+                ResourceName = theName.Substring(1);
+            }
+
+            AddStandardProperties();
+        }
+
+        private void AddStandardProperties()
+        {
+            if (SubscriptionId != "")
+            {
+                Message.azwm_SubscriptionId = SubscriptionId;
+            }
+            if (ResourceGroup != "")
+            {
+                Message.azwm_ResourceGroup = ResourceGroup;
+            }
+            if (ResourceType != "")
+            {
+                Message.azwm_ResourceType = ResourceType;
+            }
+            if (ResourceName != "")
+            {
+                Message.azwm_ResourceName = ResourceName;
+            }
+        }
+    }
+
+    public class WadLogMessage : AzureMonitorMessage
+    {
+        public WadLogMessage(dynamic message, bool hasName)
+        {
+            ResourceId = "";
+            Message = message;
+
+            ResourceType = "MICROSOFT.COMPUTE/VIRTUALMACHINES";
+            if (hasName)
+            {
+                string theName = message.dimensions.RoleInstance;
+                ResourceName = theName.Substring(1);
+            }
+
+            AddStandardProperties();
+        }
+
+        private void AddStandardProperties()
+        {
+            if (SubscriptionId != "")
+            {
+                Message.azwm_SubscriptionId = SubscriptionId;
+            }
+            if (ResourceGroup != "")
+            {
+                Message.azwm_ResourceGroup = ResourceGroup;
+            }
+            if (ResourceType != "")
+            {
+                Message.azwm_ResourceType = ResourceType;
+            }
+            if (ResourceName != "")
+            {
+                Message.azwm_ResourceName = ResourceName;
+            }
+        }
+    }
+
+    public class WadUnknownMessage : AzureMonitorMessage
+    {
+        public WadUnknownMessage(dynamic message, bool hasName)
+        {
+            ResourceId = "";
+            Message = message;
+            ResourceType = "MICROSOFT.COMPUTE/VIRTUALMACHINES";
+
+            if (hasName)
+            {
+                string theName = message.dimensions.RoleInstance;
+                ResourceName = theName.Substring(1);
+            }
+            AddStandardProperties();
+        }
+
+        private void AddStandardProperties()
+        {
+            if (SubscriptionId != "")
+            {
+                Message.azwz_SubscriptionId = SubscriptionId;
+            }
+            if (ResourceGroup != "")
+            {
+                Message.azwz_ResourceGroup = ResourceGroup;
+            }
+            if (ResourceType != "")
+            {
+                Message.azwz_ResourceType = ResourceType;
+            }
+            if (ResourceName != "")
+            {
+                Message.azwz_ResourceName = ResourceName;
+            }
+        }
     }
 
     public class MetricMessage : AzureMonitorMessage

--- a/AzureFunctionForSplunk/EhWadTelemetry.cs
+++ b/AzureFunctionForSplunk/EhWadTelemetry.cs
@@ -71,21 +71,6 @@ namespace AzureFunctionForSplunk
 
         private static List<string> MakeSplunkEventMessages(string[] messages, TraceWriter log)
         {
-            Dictionary<string, string> WADCategories = new Dictionary<string, string>();
-
-            var filename = Utils.getFilename("WadCategories.json");
-
-            // log.Info($"File name of categories dictionary is: {filename}");
-
-            try
-            {
-                WADCategories = Utils.GetDictionary(filename);
-            }
-            catch (Exception ex)
-            {
-                log.Error($"Error getting wad categories json file. {ex.Message}");
-            }
-
             List<string> splunkEventMessages = new List<string>();
 
             // each message in the array of messages can contain records of various types

--- a/AzureFunctionForSplunk/Utils.cs
+++ b/AzureFunctionForSplunk/Utils.cs
@@ -28,12 +28,12 @@ using Microsoft.Azure.WebJobs.Host;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/AzureFunctionForSplunk/WadCategories.json
+++ b/AzureFunctionForSplunk/WadCategories.json
@@ -1,3 +1,0 @@
-﻿{
-  "metricName": "azwad:metrics"
-}

--- a/AzureFunctionForSplunk/ehLadTelemetry.cs
+++ b/AzureFunctionForSplunk/ehLadTelemetry.cs
@@ -1,18 +1,44 @@
+//
+// AzureFunctionForSplunkVS
+//
+// Copyright (c) Microsoft Corporation
+//
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.ServiceBus;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using System.Dynamic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Threading.Tasks;
 
 namespace AzureFunctionForSplunk
 {
-    public static class ehLadTelemetry
+    public static class EhLadTelemetry
     {
-        [FunctionName("ehLadTelemetry")]
+        [FunctionName("EhLadTelemetry")]
         public static async Task Run(
             [EventHubTrigger("%input-hub-name-lad%", Connection = "hubConnection")]
             string[] messages, 

--- a/AzureFunctionForSplunk/ehLadTelemetry.cs
+++ b/AzureFunctionForSplunk/ehLadTelemetry.cs
@@ -1,0 +1,114 @@
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.ServiceBus;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Dynamic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace AzureFunctionForSplunk
+{
+    public static class ehLadTelemetry
+    {
+        [FunctionName("ehLadTelemetry")]
+        public static async Task Run(
+            [EventHubTrigger("%input-hub-name-lad%", Connection = "hubConnection")]
+            string[] messages, 
+            TraceWriter log)
+        {
+            //foreach (var s in messages)
+            //{
+            //    log.Info($"{s}");
+            //}
+            //return;
+
+            List<string> splunkEventMessages = MakeSplunkEventMessages(messages, log);
+
+            string outputBinding = Utils.getEnvironmentVariable("outputBinding");
+            if (outputBinding.ToUpper() == "HEC")
+            {
+                await Utils.obHEC(splunkEventMessages, log);
+            }
+            else
+            {
+                log.Info("No or incorrect output binding specified. No messages sent to Splunk.");
+            }
+
+        }
+
+        private static List<string> MakeSplunkEventMessages(string[] messages, TraceWriter log)
+        {
+            List<string> splunkEventMessages = new List<string>();
+
+            // each message in the array of messages can contain records of various types
+            // 1. perf counter
+            // 2. syslog
+
+            foreach (var message in messages)
+            {
+                var dictMessage = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(message);
+                bool isMetric = dictMessage.ContainsKey("metricName");
+                bool isLog = dictMessage.ContainsKey("category");
+
+                bool hasResourceId = dictMessage.ContainsKey("resourceId");
+                string resourceId = "";
+                if (hasResourceId)
+                {
+                    resourceId = dictMessage["resourceId"].ToString();
+                }
+
+                var expandoConverter = new ExpandoObjectConverter();
+                var expandoMessage = JsonConvert.DeserializeObject<ExpandoObject>(message, expandoConverter);
+
+                string splunkEventMessage = "";
+                if (isMetric)
+                {
+                    var ladMetricMessage = new LadMetricMessage(resourceId.ToUpper(), expandoMessage)
+                    {
+                        SplunkSourceType = "azlm:compute:vm"
+                    };
+
+                    splunkEventMessage = ladMetricMessage.GetSplunkEventFromMessage();
+                } else if (isLog)
+                {
+                    var ladLogMessage = new LadLogMessage(resourceId.ToUpper(), expandoMessage)
+                    {
+                        SplunkSourceType = "azll:compute:vm"
+                    };
+
+                    splunkEventMessage = ladLogMessage.GetSplunkEventFromMessage();
+                } else
+                {
+                    log.Warning("Unexpected message format, resourceId was provided, but neither category nor metricName exists in message. Look for sourcetype='azlx:compute:vm'");
+                    if (hasResourceId)
+                    {
+                        var ladLogMessage = new LadLogMessage(resourceId.ToUpper(), expandoMessage)
+                        {
+                            SplunkSourceType = "azlx:compute:vm"
+                        };
+
+                        splunkEventMessage = ladLogMessage.GetSplunkEventFromMessage();
+                    } else
+                    {
+                        log.Warning("Unexpected message format, resourceId was not provided, and neither were category or metricName. Look for sourcetype='azlz:compute:vm'");
+
+                        var ladUnknownMessage = new LadUnknownMessage(expandoMessage)
+                        {
+                            SplunkSourceType = "azlz:compute:vm"
+                        };
+
+                        splunkEventMessage = ladUnknownMessage.GetSplunkEventFromMessage();
+                    }
+                }
+
+                if (splunkEventMessage != "") splunkEventMessages.Add(splunkEventMessage);
+            }
+
+            return splunkEventMessages;
+
+        }
+        
+    }
+}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Azure Functions are arranged hierarchically as a Function App containing individ
 * EhMetrics - consumes Azure Monitor Metrics
 * EhWadTelemetry - consumes telemetry from Azure Windows VMs  
 
-The Activity Log goes to a hub named 'Insights-Operational-Logs'. This will be configurable at some point, but for now, the function should be configured to listen to that hub.
+The Activity Log transmits to a hub named 'Insights-Operational-Logs'. This will be configurable at some point, but for now, the function should be configured to listen to that hub.
 
 The solution leverages the capacity of an Azure Function to be triggered by arrival of messages to an Event Hub. The messages are aggregated by the Azure Functions back end so they arrive at the function already in a batch where the size of the batch depends on current message volume and settings. The batch is examined, the properties of each event are augmented, and then the events are sent via the selected output binding to the Splunk instance.  
 
@@ -60,8 +60,10 @@ Each VM to be monitored by the function app requires configuration artifacts:
 * public configuration file - tells the extension which metrics and logs you want to emit from the VM
 * private configuration file - contains credentials for the targets of the VMs telemetry  
 
-For Linux VMs, guidance on installing the extension and guidance on designing the configuration files is in this document [Use Linux Diagnostic Extension to monitor metrics and logs](https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/diagnostics-linux)  
-For Windows VMs, that same guidance is here: [Use PowerShell to enable Azure Diagnostics in a virtual machine running Windows](https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/diagnostics-windows)  
+For Linux VMs, guidance on installing the extension and guidance on designing the configuration files is in this document  
+[Use Linux Diagnostic Extension to monitor metrics and logs](https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/diagnostics-linux)  
+For Windows VMs, that same guidance is here:  
+[Use PowerShell to enable Azure Diagnostics in a virtual machine running Windows](https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/diagnostics-windows)  
 
 The private configuration file for a Linux VM will require a SAS token. A sample of C# code that generates a suitable SAS token is [here](https://github.com/sebastus/GenerateSasForEh). The sasURL in the protected config file will look something like this:  
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ At a high level, the Azure Functions approach to delivering telemetry to Splunk 
 * Azure Function is triggered by these messages
 * Azure Function delivers the messages to Splunk
 
-Azure Functions are arranged hierarchically as a Function App containing individual functions within. An individual function is triggered by a single event hub. Regarding logs from Azure Monitor, each log category CAN BE sent to its own hub. Each Azure Resource Provider that emits logs may emit more than one log category. Similarly, metrics are sent to a hub as configured by the user. Hence, there MAY BE many hubs for the Function App to watch over. BUT, you can configure all diagnostic logs to go to the same hub. This practice is recommended for simplicity's sake. 
+Azure Functions are arranged hierarchically as a Function App containing individual functions within. An individual function is triggered by a single event hub. Regarding logs from Azure Monitor, each log category CAN BE sent to its own hub. Each Azure Resource Provider that emits logs may emit more than one log category. Similarly, metrics are sent to a hub as configured by the user. Hence, there MAY BE many hubs for the Function App to watch over. BUT, you can configure all diagnostic logs to go to the same hub. This practice is recommended for simplicity's sake.  
+
+### Functions in the Function App
+* EhActivityLogs - consumes Azure Monitor Activity Logs
+* EhDiagnosticLogs - consumes Azure Monitor Diagnostic Logs
+* EhLadTelemetry - consumes telemetry from Azure Linux VMs
+* EhMetrics - consumes Azure Monitor Metrics
+* EhWadTelemetry - consumes telemetry from Azure Windows VMs  
 
 The Activity Log goes to a hub named 'Insights-Operational-Logs'. This will be configurable at some point, but for now, the function should be configured to listen to that hub.
 
@@ -42,11 +49,25 @@ Installation and Configuration tasks for the overall solution fall into a few bu
 * Splunk instance
 * Azure Function
 
-
 ### Diagnostics Profiles
 Each resource to be monitored must have a diagnostics profile created for it. This can be done in the portal, but more likely you'll want to write a script to configure existing resources and update your solution templates to create these profiles upon creation of the resource. Here's a place to start:
 
 [Automatically enable Diagnostic Settings at resource creation using a Resource Manager template](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-enable-diagnostic-logs-using-template)
+
+### Diagnostic Profiles for VMs
+Each VM to be monitored by the function app requires configuration artifacts:  
+* Diagnostic Extension designed for the OS
+* public configuration file - tells the extension which metrics and logs you want to emit from the VM
+* private configuration file - contains credentials for the targets of the VMs telemetry  
+
+For Linux VMs, guidance on installing the extension and guidance on designing the configuration files is in this document [Use Linux Diagnostic Extension to monitor metrics and logs](https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/diagnostics-linux)  
+For Windows VMs, that same guidance is here: [Use PowerShell to enable Azure Diagnostics in a virtual machine running Windows](https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/diagnostics-windows)  
+
+The private configuration file for a Linux VM will require a SAS token. A sample of C# code that generates a suitable SAS token is [here](https://github.com/sebastus/GenerateSasForEh). The sasURL in the protected config file will look something like this:  
+
+```
+https://namespace.servicebus.windows.net/insights-telemetry-lad?sr=https%3a%2f%2fnamespace.servicebus.windows.net%2finsights-telemetry-lad&sig=wsVxC%2f%2bm7vRhOZjm%2fJMEWTX%2by0sOil6z%2bFqwoWrstkQ%3d&se=1562845709&skn=RootManageSharedAccessKey  
+```
 
 ### Event hubs
 


### PR DESCRIPTION
Adds the ability to monitor the telemetry feed (via Event Hub) coming from Linux VMs on Azure. Each VM sends its data to a single event hub, even though in the most general case the various sources of data in the VM could go to different event hubs.